### PR TITLE
Correct handling of NaN inputs to comparator

### DIFF
--- a/src/Endpoint.h
+++ b/src/Endpoint.h
@@ -2,6 +2,7 @@
 
 #define ENDPOINT_H
 
+#include <cmath>
 #include <vector>
 
 #include <R.h>
@@ -36,6 +37,8 @@ public:
       exact equality is intended by the calling code. Given this assumption,
       there is no need for a relative difference approach here.
     */
+    if (std::isnan(other.pos)) return false;
+    if (std::isnan(this->pos)) return true;
     if ( this->pos == other.pos ) 
       return( this->state() < other.state() );
     else


### PR DESCRIPTION
At HEAD, our tooling is throwing an error on this `operator<` because it is not a strict weak ordering:

https://www.boost.org/sgi/stl/StrictWeakOrdering.html

As summarized:

> As doubles/floats can be `NaN` which means `x < NaN` and `NaN < x` are both `false` and that means `x` is equivalent to `NaN` thus for every finite `x` we have `x == NaN` but clearly `x == NaN` and `y == NaN` does not imply `x == y`.